### PR TITLE
feat(dx): initial project scaffolding and configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+*.{js,jsx,ts,tsx,json,md,yml,yaml} text eol=lf

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "bradlc.vscode-tailwindcss",
+    "eamodio.gitlens",
+    "ms-azuretools.vscode-docker",
+    "github.vscode-github-actions"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,12 @@
 {
-  "tailwindCSS.experimental.configFile": "packages/ui/src/styles/globals.css"
+  "editor.formatOnSave": true,
+  // Set Prettier as the default formatter.
+  // Ensure you have the Prettier extension installed: esbenp.prettier-vscode
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "tailwindCSS.experimental.configFile": "packages/ui/tailwind.config.ts"
 }

--- a/COMMIT_MSG.tmp
+++ b/COMMIT_MSG.tmp
@@ -1,0 +1,18 @@
+feat(dx): initial project scaffolding and configuration
+
+this initial commit establishes a robust foundation for the project, focusing on developer experience (dx) and modern configuration standards. it addresses several inconsistencies and sets up the monorepo for scalable contributions.
+
+- vscode & editor config:
+  - introduced `.vscode/settings.json` and `extensions.json` to enforce consistent formatting (prettier on save) and recommend essential extensions. this minimizes style drift and lowers the barrier for new contributors.
+  - added `.gitattributes` to normalize line endings (lf), preventing cross-platform git noise.
+
+- typescript & build integrity:
+  - resolved a series of cascading typescript errors stemming from the monorepo setup. corrected the `tsconfig.json` `extends` to use a relative path, as module path aliases aren't resolved for this property.
+  - updated the shared `nextjs.json` config with `jsx: "react-jsx"` and `jsxImportSource: "react"`. this is critical for react 19's jsx transform and ensures the compiler can correctly resolve jsx typings across the workspace.
+
+- baseline cleanup:
+  - refactored the boilerplate `page.tsx` to provide a cleaner, more structured starting point for the web application.
+
+this groundwork ensures the project is stable, easy to work with, and ready for feature development.
+
+-kofi :)

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -2,11 +2,14 @@ import { Button } from "@call/ui/components/button";
 
 export default function Page() {
   return (
-    <div className="flex items-center justify-center min-h-svh">
-      <div className="flex flex-col items-center justify-center gap-4">
-        <h1 className="text-2xl font-bold">Hello World</h1>
-        <Button size="sm">Button</Button>
+    <main className="flex flex-col items-center justify-center min-h-screen p-24">
+      <header className="text-center">
+        <h1 className="text-4xl font-bold">Welcome to Call</h1>
+        <p className="text-lg text-muted-foreground">The open-source alternative to Google Meet and Zoom.</p>
+      </header>
+      <div className="mt-8">
+        <Button>Get Started</Button>
       </div>
-    </div>
+    </main>
   );
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@call/typescript-config/nextjs.json",
+  "extends": "../../packages/typescript-config/nextjs.json",
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
@@ -7,7 +7,7 @@
       "@call/ui/*": ["../../packages/ui/src/*"],
       "@call/db/*": ["../../packages/db/src/*"],
       "@call/eslint-config": ["../../packages/eslint-config/src/*"],
-      "@call/typescript-config": ["../../packages/typescript-config/src/*"]
+      "@call/typescript-config/*": ["../../packages/typescript-config/*"]
     },
     "plugins": [
       {

--- a/packages/typescript-config/nextjs.json
+++ b/packages/typescript-config/nextjs.json
@@ -7,7 +7,8 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "allowJs": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
+    "jsxImportSource": "react",
     "noEmit": true
   }
 }


### PR DESCRIPTION
heyo,

had some time this evening and thought i'd lay down some foundational groundwork to make development a bit smoother for everyone. this pr is mostly about improving dx and shoring up the build configuration to prevent common issues down the line.

here's a quick rundown:

**developer experience**

added vscode settings and extension recommendations. this ensures everyone gets consistent formatting on save and has the right tools, which helps keep the codebase clean with less effort.
normalized line endings with a `.gitattributes` file. just a small thing to prevent annoying diffs between windows and unix-like systems.

**build & type integrity**

fixed the typescript pathing in the web app's `tsconfig.json`. the extends field doesn't resolve path aliases, so it needed a direct relative path to the shared config. this was the root cause of a lot of the initial jsx errors.
updated the shared `nextjs.json` tsconfig for the react 19 jsx transform ("jsx": "react-jsx"). this is the modern standard and ensures our type system understands the new jsx runtime without needing import react from 'react' everywhere.

**cleanup**

gave the main `page.tsx` a quick cleanup. just a slightly more structured starting point.




anyway, just some foundational stuff to build on. hope it helps.

cheers.

-kofi :)