### PR TITLE
feat(dx): add vscode devcontainers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,57 @@
+# Use Ubuntu as the base image
+FROM ubuntu:latest
+
+# Avoid prompts from apt
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install basic dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    wget \
+    build-essential \
+    pkg-config \
+    zip \
+    unzip \
+    zsh \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create workspace directory
+RUN mkdir -p /workspaces
+
+# Set working directory
+WORKDIR /workspaces
+
+# Install zsh
+RUN apt-get update && apt-get install -y zsh
+
+#  install Oh My Zsh
+RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+
+# Bun and pnpm installation
+RUN curl -fsSL https://bun.sh/install | bash
+RUN wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.bashrc" SHELL="$(which bash)" bash -
+
+# Register Bun in bashrc and zshrc
+RUN echo 'export PATH="$HOME/.bun/bin:$PATH"' >> ~/.bashrc
+RUN echo 'export PATH="$HOME/.bun/bin:$PATH"' >> ~/.zshrc
+
+# Install NVM and Node.js
+ENV NVM_DIR=/root/.nvm
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+
+# Install Node.js and set it up using a shell
+RUN . $NVM_DIR/nvm.sh && \
+    nvm install --lts && \
+    nvm use --lts && \
+    nvm alias default 'lts/*' && \
+    npm install -g bun
+
+# Register Nvm in bashrc and zshrc
+RUN echo 'export NVM_DIR="$HOME/.nvm"' >> ~/.bashrc
+RUN echo 'export NVM_DIR="$HOME/.nvm"' >> ~/.zshrc
+RUN echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm' >> ~/.bashrc
+RUN echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm' >> ~/.zshrc
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose
+{
+    "name": "Call0dotCo Dev Container",
+    "build": {
+      "dockerfile": "Dockerfile",
+      "context": "."
+    },
+    // The optional 'workspaceFolder' property is the path VS Code should open by default when
+    // connected. This is typically a file mount in .devcontainer/docker-compose.yml
+    "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  
+    // Features to add to the dev container
+    "features": {
+      "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+    },
+  
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    "forwardPorts": [3000],
+  
+    // Configure tool-specific properties.
+    "customizations": {
+      "vscode": {
+        "extensions": [
+          "ms-azuretools.vscode-docker",
+          "eamodio.gitlens",
+          "esbenp.prettier-vscode",
+          "dbaeumer.vscode-eslint",
+          "bradlc.vscode-tailwindcss",
+          "streetsidesoftware.code-spell-checker"
+        ],
+        "settings": {}
+      }
+    },
+  
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": "apt update && apt install -y zsh && zsh"
+  }


### PR DESCRIPTION
## Pull Request

### Description

This PR adds support for **VS Code Dev Containers** to streamline onboarding and ensure a consistent development environment across team members.
The `.devcontainer` includes a Docker-based setup with pre-installed dependencies required for local development.

### Notes for Reviewer

You can now open the project directly in a containerized dev environment using the `Reopen in Container` option in VS Code.
Let me know if we should tweak any dependencies or settings inside the `.devcontainer.json`.
