### PR TITLE
feat(ux): add url navigation for sections

### DIFF
--- a/apps/web/app/(app)/app/call/page.tsx
+++ b/apps/web/app/(app)/app/call/page.tsx
@@ -1,0 +1,9 @@
+import CallSection from "@/components/app/section/call-section";
+
+export default function CallPage() {
+  return (
+    <>
+      <CallSection />
+    </>
+  );
+} 

--- a/apps/web/app/(app)/app/contact/page.tsx
+++ b/apps/web/app/(app)/app/contact/page.tsx
@@ -1,0 +1,9 @@
+import ContactSection from "@/components/app/section/contact-section";
+
+export default function ContactPage() {
+  return (
+    <>
+      <ContactSection />
+    </>
+  );
+} 

--- a/apps/web/app/(app)/app/layout.tsx
+++ b/apps/web/app/(app)/app/layout.tsx
@@ -1,0 +1,50 @@
+"use client";
+import { AppSidebar } from "@/components/app/section/_components/app-sidebar";
+import { SidebarInset, SidebarProvider, SidebarTrigger } from "@call/ui/components/sidebar";
+import { Separator } from "@call/ui/components/separator";
+import { Button } from "@call/ui/components/button";
+import { usePathname, useRouter } from "next/navigation";
+
+const sectionMap = [
+  { path: "/app/call", title: "Call" },
+  { path: "/app/teams", title: "Teams" },
+  { path: "/app/contact", title: "Contact" },
+  { path: "/app/schedule", title: "Schedule" },
+];
+
+export default function AppLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const router = useRouter();
+  // Find the section that matches the current path
+  const selectedSection = sectionMap.find((s) => pathname?.startsWith(s.path))?.title || "Call";
+
+  const handleSectionSelect = (title: string) => {
+    const section = sectionMap.find((s) => s.title === title);
+    if (section) {
+      router.push(section.path);
+    }
+  };
+
+  return (
+    <SidebarProvider>
+      <AppSidebar selectedSection={selectedSection} onSectionSelect={handleSectionSelect} />
+      <SidebarInset>
+        <header className="flex h-16 shrink-0 items-center gap-2 border-b transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
+          <div className="flex w-full items-center justify-between gap-2 px-4">
+            <div className="flex items-center">
+              <SidebarTrigger className="-ml-1" />
+              <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
+              {/* Section title can be rendered by each page */}
+            </div>
+            <div>
+              <Button>Start Call</Button>
+            </div>
+          </div>
+        </header>
+        <div className="flex flex-1 flex-col gap-4 border p-4">
+          {children}
+        </div>
+      </SidebarInset>
+    </SidebarProvider>
+  );
+} 

--- a/apps/web/app/(app)/app/page.tsx
+++ b/apps/web/app/(app)/app/page.tsx
@@ -1,61 +1,6 @@
-// This file defines the main page layout for the app section, including the sidebar, header, breadcrumbs, and main content area.
-"use client";
-import { AppSidebar } from "@/components/app/section/_components/app-sidebar";
-import { Button } from "@call/ui/components/button";
-import { Separator } from "@call/ui/components/separator";
-import {
-  SidebarInset,
-  SidebarProvider,
-  SidebarTrigger,
-} from "@call/ui/components/sidebar";
-import CallSection from "@/components/app/section/call-section";
-import TeamSection from "@/components/app/section/team-section";
-import ContactSection from "@/components/app/section/contact-section";
-import ScheduleSection from "@/components/app/section/schedule-section";
-import { useState } from "react";
+import { redirect } from "next/navigation";
 
 export default function Page() {
-  const [selectedSection, setSelectedSection] = useState("Call");
-
-  let SectionComponent = null;
-  if (selectedSection === "Call") SectionComponent = <CallSection />;
-  else if (selectedSection === "Teams") SectionComponent = <TeamSection />;
-  else if (selectedSection === "Contact") SectionComponent = <ContactSection />;
-  else if (selectedSection === "Schedule") SectionComponent = <ScheduleSection />;
-
-  return (
-    // SidebarProvider manages sidebar state for the layout
-    <SidebarProvider>
-      {/* Main sidebar for navigation and user info */}
-      <AppSidebar
-        selectedSection={selectedSection}
-        onSectionSelect={setSelectedSection}
-      />
-      {/* SidebarInset wraps the main content area, including header and page content */}
-      <SidebarInset>
-        {/* Header with sidebar trigger, separator, and breadcrumbs */}
-        <header className="flex h-16 shrink-0 items-center gap-2 border-b transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
-          <div className="flex w-full items-center justify-between gap-2 px-4">
-            <div className="flex items-center">
-              <SidebarTrigger className="-ml-1" />
-
-              <Separator
-                orientation="vertical"
-                className="mr-2 data-[orientation=vertical]:h-4"
-              />
-
-              <p>{selectedSection}</p>
-            </div>
-            <div>
-              <Button>Start Call</Button>
-            </div>
-          </div>
-        </header>
-        {/* Main content area with two sections: a grid and a flexible content box */}
-        <div className="flex flex-1 flex-col gap-4 border p-4">
-          {SectionComponent}
-        </div>
-      </SidebarInset>
-    </SidebarProvider>
-  );
+  redirect("/app/call");
+  return null;
 }

--- a/apps/web/app/(app)/app/schedule/page.tsx
+++ b/apps/web/app/(app)/app/schedule/page.tsx
@@ -1,0 +1,9 @@
+import ScheduleSection from "@/components/app/section/schedule-section";
+
+export default function SchedulePage() {
+  return (
+    <>
+      <ScheduleSection />
+    </>
+  );
+} 

--- a/apps/web/app/(app)/app/teams/page.tsx
+++ b/apps/web/app/(app)/app/teams/page.tsx
@@ -1,0 +1,9 @@
+import TeamSection from "@/components/app/section/team-section";
+
+export default function TeamsPage() {
+  return (
+    <>
+      <TeamSection />
+    </>
+  );
+} 


### PR DESCRIPTION
## Pull Request

### Description

This PR refactors the navigation for the /app section to use route-based navigation instead of local state and conditional rendering. Each section (Call, Teams, Contact, Schedule) now has its own dedicated route and page component under /app/(app)/app/. A master layout (layout.tsx) wraps all section pages, providing a consistent sidebar and header across the app. The sidebar now highlights the active section based on the current route, and navigation between sections updates the URL accordingly.

Key changes:
* Created individual pages for /app/call, /app/teams, /app/contact, and /app/schedule.
* Added a master layout to render the sidebar and header for all section pages.
* Updated the sidebar to use the current route for determining the selected section.
* Navigation between sections now uses Next.js routing, ensuring deep-linking and browser navigation work as expected.
* The root /app route now redirects to /app/call by default.
* No new dependencies were added.

Fixes: #76  (if applicable)

---

### Checklist

- [*] I have tested my changes locally
- [ ] I have added necessary documentation (if needed)
- [ ] I have added/updated tests (if applicable)
- [*] I have run `pnpm build` or `pnpm lint` with no errors
- [*] This pull request is ready for review

---

### Screenshots or UI Changes (if applicable)



---

### Related Issues



---

### Notes for Reviewer

* Please verify that navigation between sections works as expected and that the sidebar correctly highlights the active section.
* Let me know if you have suggestions for improving the sidebar UX or if you notice any regressions in navigation or layout.
