### PR TITLE
fix: add missing dependency to ensure clean pnpm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-tabs": "^1.1.12",
     "chalk": "^5.4.1",
+    "date-fns": "^4.1.0",
     "dotenv": "^16.5.0",
     "mediasoup-client": "^3.12.5",
     "zod": "^3.25.67"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       chalk:
         specifier: ^5.4.1
         version: 5.4.1
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       dotenv:
         specifier: ^16.5.0
         version: 16.5.0


### PR DESCRIPTION
Just added date-fns dep.
as it was not added in packages through `pnpm add` earlier