### PR TITLE
feat(setup): auto-compile mediasoup worker and ensure build essentials in setup-dev.sh

### DIFF
--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -3,6 +3,7 @@
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'
 RED='\033[0;31m'
+YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 print_step() {
@@ -15,6 +16,125 @@ print_success() {
 
 print_error() {
   echo -e "${RED}==>${NC} $1"
+}
+
+print_warning() {
+  echo -e "${YELLOW}==>${NC} $1"
+}
+
+# Function to detect OS and install build essentials
+install_build_essentials() {
+  print_step "Checking for build essentials..."
+  
+  # Check if make is available
+  if ! command -v make &> /dev/null; then
+    print_warning "make is not installed. Installing build essentials..."
+    
+    # Detect OS and install appropriate build tools
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      # macOS
+      if command -v brew &> /dev/null; then
+        print_step "Installing build essentials via Homebrew..."
+        brew install make gcc python3
+        print_success "Build essentials installed via Homebrew"
+      else
+        print_error "Homebrew is not installed. Please install Homebrew first:"
+        echo "  /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\""
+        echo "Then run: brew install make gcc python3"
+        exit 1
+      fi
+    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+      # Linux
+      if command -v apt-get &> /dev/null; then
+        # Debian/Ubuntu
+        print_step "Installing build essentials via apt..."
+        sudo apt-get update
+        sudo apt-get install -y build-essential python3
+        print_success "Build essentials installed via apt"
+      elif command -v yum &> /dev/null; then
+        # CentOS/RHEL/Fedora
+        print_step "Installing build essentials via yum..."
+        sudo yum groupinstall -y "Development Tools"
+        sudo yum install -y python3
+        print_success "Build essentials installed via yum"
+      elif command -v dnf &> /dev/null; then
+        # Fedora (newer versions)
+        print_step "Installing build essentials via dnf..."
+        sudo dnf groupinstall -y "Development Tools"
+        sudo dnf install -y python3
+        print_success "Build essentials installed via dnf"
+      else
+        print_error "Could not detect package manager. Please install build-essential and python3 manually."
+        exit 1
+      fi
+    elif [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "win32" ]] || [[ -n "$WINDIR" ]]; then
+      # Windows
+      print_step "Detected Windows system..."
+      
+      # Check if we're in WSL
+      if grep -q Microsoft /proc/version 2>/dev/null; then
+        print_step "Detected WSL (Windows Subsystem for Linux)..."
+        if command -v apt-get &> /dev/null; then
+          print_step "Installing build essentials via apt in WSL..."
+          sudo apt-get update
+          sudo apt-get install -y build-essential python3
+          print_success "Build essentials installed via apt in WSL"
+        else
+          print_error "WSL detected but apt-get not available. Please install build-essential and python3 manually."
+          exit 1
+        fi
+      else
+        # Native Windows (Git Bash, MSYS2, etc.)
+        print_warning "Native Windows detected. For mediasoup compilation, you need:"
+        echo "  1. Visual Studio Build Tools or Visual Studio Community"
+        echo "  2. Python 3.x"
+        echo "  3. Node.js with npm/pnpm"
+        echo ""
+        echo "Please install these manually:"
+        echo "  - Visual Studio Build Tools: https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022"
+        echo "  - Python: https://www.python.org/downloads/"
+        echo ""
+        echo "After installation, run this script again."
+        exit 1
+      fi
+    else
+      print_error "Unsupported OS: $OSTYPE. Please install build essentials manually."
+      exit 1
+    fi
+  else
+    print_success "Build essentials are already installed"
+  fi
+}
+
+# Function to compile mediasoup worker
+compile_mediasoup_worker() {
+  print_step "Checking for mediasoup worker compilation..."
+  
+  local worker_dir="apps/server/node_modules/mediasoup/worker"
+  
+  if [ ! -d "$worker_dir" ]; then
+    print_warning "mediasoup worker directory not found. Skipping compilation."
+    return 0
+  fi
+  
+  # Check if worker binary already exists
+  if [ -f "$worker_dir/out/Release/mediasoup-worker" ] || [ -f "$worker_dir/out/Release/mediasoup-worker.exe" ]; then
+    print_success "mediasoup worker binary already exists"
+    return 0
+  fi
+  
+  print_step "Compiling mediasoup worker..."
+  cd "$worker_dir"
+  
+  if make; then
+    print_success "mediasoup worker compiled successfully"
+  else
+    print_error "Failed to compile mediasoup worker"
+    print_warning "You may need to install additional dependencies or check the error above"
+    return 1
+  fi
+  
+  cd - > /dev/null
 }
 
 if [ ! -f .env ]; then
@@ -46,6 +166,10 @@ if [ ! -d "node_modules" ]; then
   pnpm install
   print_success "Dependencies installed"
 fi
+
+# Install build essentials and compile mediasoup worker
+install_build_essentials
+compile_mediasoup_worker
 
 print_step "Starting Docker services..."
 docker compose up -d


### PR DESCRIPTION
## Pull Request

### Description

This PR enhances the setup-dev.sh script to automatically compile the mediasoup worker after installing dependencies in apps/server. It also ensures that all required build tools (make, gcc, python3) are present on the developer's machine, with support for macOS, Linux, WSL, and native Windows environments.
Adds OS detection and installs build essentials automatically for macOS, Linux, and WSL.
Provides clear manual installation instructions for native Windows users (Visual Studio Build Tools, Python).
Improves script output with colored warnings and clearer error handling.
Ensures a smoother onboarding experience for new contributors and consistent mediasoup setup across platforms.

Fixes: #[issue_number] (if applicable)

---

### Checklist

- [x] I have tested my changes locally
- [ ] I have added necessary documentation (if needed)
- [ ] I have added/updated tests (if applicable)
- [x] I have run `pnpm build` or `pnpm lint` with no errors
- [x] This pull request is ready for review

---

### Screenshots or UI Changes (if applicable)

Add screenshots, recordings, or before/after comparisons here.

---

### Related Issues

Reference any related issues or PRs here.

---

### Notes for Reviewer

* Please review the OS detection logic and the mediasoup worker compilation step for cross-platform compatibility.
* Let me know if you have suggestions for further improving the developer onboarding flow.
