### PR TITLE
fix(socket): correct WebSocket protocol typo from 'wsl' to 'ws'

### DIFF
--- a/apps/web/hooks/useSocket.ts
+++ b/apps/web/hooks/useSocket.ts
@@ -8,7 +8,7 @@ config({ path: resolve(process.cwd(), "../../.env") });
 
 const getSocketUrl = () => {
   if (typeof window === "undefined") return "ws://localhost:4001";
-  const protocol = window.location.protocol === "https:" ? "wss:" : "wsl:";
+  const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
   const host = "localhost";
   const port = "4001";
 


### PR DESCRIPTION
### Description : 
Fixed a typo in the WebSocket protocol where wsl: was mistakenly used instead of ws:.
This caused WebSocket initialization to fail, preventing the application from starting correctly.

```
- const protocol = window.location.protocol === "https:" ? "wss:" : "wsl:";
+ const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
```


<img width="1130" height="627" alt="image" src="https://github.com/user-attachments/assets/abb300fe-746f-4624-acb0-c3aa1f2711ba" />



---

### Checklist

- [x] I have tested my changes locally
- [ ] I have added necessary documentation (if needed)
- [x] I have added/updated tests (if applicable)
- [x] I have run `pnpm build` or `pnpm lint` with no errors
- [x] This pull request is ready for review

---

### Screenshots or UI Changes (if applicable)
N/A

### Related Issues
N/A

### Notes for Reviewer
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where WebSocket connections over HTTP used an incorrect protocol, ensuring reliable connectivity for non-HTTPS pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->