### PR TITLE
feat: send call invite mail to the users

### DIFF
--- a/apps/server/src/routes/calls/index.ts
+++ b/apps/server/src/routes/calls/index.ts
@@ -12,6 +12,7 @@ import {
 } from "@call/db/schema";
 import { eq, inArray, desc, and, sql } from "drizzle-orm";
 import type { ReqVariables } from "../../index.js";
+import { sendMail } from '@call/auth/utils/send-mail';
 
 const callsRoutes = new Hono<{ Variables: ReqVariables }>();
 
@@ -133,6 +134,13 @@ callsRoutes.post("/create", async (c) => {
           createdAt: new Date(),
         });
         console.log(`✅ [CALLS DEBUG] Notification created for ${email}`);
+        
+        await sendMail({
+          to: email,
+          subject: "Invitation to join Call",
+          text: `Hello,\n\n${user.name || user.email} is inviting you to a call: ${name}\n\nJoin the call: ${process.env.FRONTEND_URL}/calls/${callId}`,
+        });
+        console.log(`✅ [CALLS DEBUG] Email sent to ${email}`);
       }
     }
     console.log("✅ [CALLS DEBUG] All invitations and notifications created");


### PR DESCRIPTION
Send mail to all the people you invited to the call with the meeting link so that they can get notified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email invitations are now sent automatically when creating call invitations, providing invitees with call details and a join link.

* **Other**
  * Improved tracking of the email sending process with additional debug logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->