### PR TITLE
fix: send invitation to users for call

### DIFF
--- a/apps/server/src/routes/calls/index.ts
+++ b/apps/server/src/routes/calls/index.ts
@@ -135,12 +135,18 @@ callsRoutes.post("/create", async (c) => {
         });
         console.log(`✅ [CALLS DEBUG] Notification created for ${email}`);
         
-        await sendMail({
-          to: email,
-          subject: "Invitation to join Call",
-          text: `Hello,\n\n${user.name || user.email} is inviting you to a call: ${name}\n\nJoin the call: ${process.env.FRONTEND_URL}/calls/${callId}`,
-        });
-        console.log(`✅ [CALLS DEBUG] Email sent to ${email}`);
+        // Try sending email, but do not fail the whole request if it errors
+        try {
+          await sendMail({
+            to: email,
+            subject: "Invitation to join Call",
+            text: `Hello,\n\n${user.name || user.email} is inviting you to a call: ${name}\n\nJoin the call: ${process.env.FRONTEND_URL}/calls/${callId}`,
+          });
+          console.log(`✅ [CALLS DEBUG] Email sent to ${email}`);
+        } catch (emailError) {
+          console.error(`⚠️ [CALLS DEBUG] Failed to send email to ${email}:`, emailError);
+          // Continue without throwing so the call creation succeeds
+        }
       }
     }
     console.log("✅ [CALLS DEBUG] All invitations and notifications created");

--- a/apps/web/lib/QUERIES.ts
+++ b/apps/web/lib/QUERIES.ts
@@ -26,7 +26,7 @@ export const CALLS_QUERY = {
     if (res.status === 200) {
       return res.data;
     }
-    throw new Error("Failed to fetch calls");
+    throw new Error("Failed to create call");
   },
   getCalls: async () => {
     const res = await apiClient.get("/calls/participated");

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -57,6 +57,9 @@ export const auth = betterAuth({
       domain: "joincall.co",
     },
   },
+  verification: {
+    disableCleanup: true,
+  },
 });
 
 export type Session = typeof auth.$Infer.Session;


### PR DESCRIPTION
## Pull Request

### Description

When inviting a user to a call so they can join directly, the user receives it but the creator gets an error. This issue is now resolved.

Fixes: #221 (if applicable)

---

### Checklist

- [ ] I have tested my changes locally
- [ ] I have added necessary documentation (if needed)
- [ ] I have added/updated tests (if applicable)
- [ ] I have run `pnpm build` or `pnpm lint` with no errors
- [ ] This pull request is ready for review

---

### Screenshots or UI Changes (if applicable)

Add screenshots, recordings, or before/after comparisons here.

---

### Related Issues

Reference any related issues or PRs here.

---

### Notes for Reviewer

Any special instructions, context, or things to pay attention to.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of call invitation creation by ensuring that email delivery failures do not block the process.
  * Updated error message when creating a call to provide clearer feedback.

* **Chores**
  * Adjusted authentication configuration to enhance verification settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->