### PR TITLE
Update: "Join a Call" Card Background to Match Sidebar Theme

### DIFF
--- a/apps/web/components/app/section/_components/join-call-box.tsx
+++ b/apps/web/components/app/section/_components/join-call-box.tsx
@@ -42,7 +42,7 @@ export function JoinCallBox() {
   return (
     <div className="bg-background mx-auto mt-8 grid max-w-2xl grid-cols-1 overflow-hidden rounded-xl border shadow-lg md:grid-cols-3">
       {/* Left Panel: Information */}
-      <div className="bg-muted/70 col-span-1 hidden flex-col items-center justify-center border-r p-8 text-center md:flex">
+      <div className="bg-sidebar col-span-1 hidden flex-col items-center justify-center border-r p-8 text-center md:flex">
         <div className="bg-secondary/20 rounded-full p-4">
           <LogIn className="text-secondary-foreground h-10 w-10" />
         </div>


### PR DESCRIPTION
Changed the Join a Call card background color from bg-muted/70  to bg-sidebar for better visual consistency with the dark sidebar. This improves UI cohesiveness and reduces visual distraction between components.

Before
<img width="1919" height="883" alt="image" src="https://github.com/user-attachments/assets/7a08ab8d-430a-4775-9519-ea2915f01fa6" />

After
<img width="1919" height="881" alt="image" src="https://github.com/user-attachments/assets/9ff67697-8eca-435c-a4dc-7ab8f7c6dbb3" />
