### PR TITLE
feat(header): add close/open sidebar button and fix avatar fallback

### DIFF
--- a/apps/web/app/(app)/app/call/page.tsx
+++ b/apps/web/app/(app)/app/call/page.tsx
@@ -8,6 +8,7 @@ import { cn } from "@call/ui/lib/utils";
 import { motion as m } from "motion/react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useMemo } from "react";
+import { CloseSidebarButton } from "@/components/app/section/_components/close-sidebar-button";
 
 const SECTIONS = [
   { key: "joincall", label: "Join Call" },
@@ -39,6 +40,7 @@ export default function CallPage() {
     <div className="flex flex-col gap-[22px]">
       <Header className="justify-between">
         <div className="flex items-center gap-2">
+          <CloseSidebarButton className="-ml-8" />
           {SECTIONS.map((s) => (
             <m.button
               key={s.key}

--- a/apps/web/app/(app)/app/contact/page.tsx
+++ b/apps/web/app/(app)/app/contact/page.tsx
@@ -4,13 +4,16 @@ import ContactsList from "@/components/app/section/contacts-list";
 import Header from "@/components/app/header";
 import { Button } from "@call/ui/components/button";
 import { useModal } from "@/hooks/use-modal";
+import { CloseSidebarButton } from "@/components/app/section/_components/close-sidebar-button";
 
 export default function ContactPage() {
   const { onOpen } = useModal();
   return (
     <div className="flex flex-col gap-[22px]">
       <Header className="justify-between">
-        <div></div>
+        <div>
+          <CloseSidebarButton className="-ml-8" />
+        </div>
         <Button
           onClick={() => onOpen("create-contact")}
           className="bg-inset-accent-foreground hover:bg-inset-accent-foreground/80 text-white"

--- a/apps/web/app/(app)/app/notifications/page.tsx
+++ b/apps/web/app/(app)/app/notifications/page.tsx
@@ -7,6 +7,7 @@ import { cn } from "@call/ui/lib/utils";
 import { motion as m } from "motion/react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useMemo } from "react";
+import { CloseSidebarButton } from "@/components/app/section/_components/close-sidebar-button";
 
 const SECTIONS = [
   { key: "all", label: "All notifications" },
@@ -40,6 +41,7 @@ export default function NotificationsPage() {
     <div className="flex flex-col gap-[22px]">
       <Header className="justify-between">
         <div className="flex items-center gap-2">
+          <CloseSidebarButton className="-ml-8" />
           {SECTIONS.map((s) => (
             <m.button
               key={s.key}
@@ -65,4 +67,4 @@ export default function NotificationsPage() {
       <NotificationSection section={sectionKey} />
     </div>
   );
-} 
+}

--- a/apps/web/app/(app)/app/profile/page.tsx
+++ b/apps/web/app/(app)/app/profile/page.tsx
@@ -8,9 +8,17 @@ import { Label } from "@call/ui/components/label";
 import { UserProfile } from "@call/ui/components/use-profile";
 import { useRef, useState } from "react";
 import { toast } from "sonner";
-import { FiCamera, FiMail, FiCalendar, FiEdit2, FiCheck, FiX } from "react-icons/fi";
+import {
+  FiCamera,
+  FiMail,
+  FiCalendar,
+  FiEdit2,
+  FiCheck,
+  FiX,
+} from "react-icons/fi";
 import { Badge } from "@call/ui/components/badge";
 import { Separator } from "@call/ui/components/separator";
+import { CloseSidebarButton } from "@/components/app/section/_components/close-sidebar-button";
 
 export default function ProfilePage() {
   const { user } = useSession();
@@ -102,13 +110,21 @@ export default function ProfilePage() {
   };
 
   return (
-    <div className="min-h-[calc(100vh-4rem)]  from-primary/5 to-background p-8">
+    <div className="from-primary/5 to-background min-h-[calc(100vh-4rem)] p-8">
       <div className="mx-auto max-w-4xl space-y-8">
         {/* Header Section */}
         <div className="flex flex-col items-center space-y-4 text-center">
-          <div className="group relative cursor-pointer" onClick={handleImageClick}>
+          <div
+            className="group relative cursor-pointer"
+            onClick={handleImageClick}
+          >
             <div className="relative h-32 w-32">
-              <UserProfile name={user.name} url={user.image} className="h-full w-full" size="lg" />
+              <UserProfile
+                name={user.name}
+                url={user.image}
+                className="h-full w-full"
+                size="lg"
+              />
               <div className="absolute inset-0 flex items-center justify-center rounded-lg bg-black/0 transition-colors group-hover:bg-black/40">
                 <FiCamera className="hidden h-8 w-8 text-white group-hover:block" />
               </div>
@@ -137,7 +153,11 @@ export default function ProfilePage() {
                   className="h-10 text-xl font-semibold"
                   disabled={loading}
                 />
-                <Button size="icon" onClick={handleUpdateProfile} disabled={loading}>
+                <Button
+                  size="icon"
+                  onClick={handleUpdateProfile}
+                  disabled={loading}
+                >
                   <FiCheck className="h-4 w-4" />
                 </Button>
                 <Button
@@ -155,24 +175,26 @@ export default function ProfilePage() {
             ) : (
               <div className="flex items-center justify-center gap-2">
                 <h1 className="text-2xl font-semibold">{user.name}</h1>
-                <Button size="icon" variant="ghost" onClick={() => setIsEditing(true)}>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  onClick={() => setIsEditing(true)}
+                >
                   <FiEdit2 className="h-4 w-4" />
                 </Button>
               </div>
             )}
             <p className="text-muted-foreground">{user.email}</p>
           </div>
-
-        
         </div>
 
         <Separator />
 
         {/* Stats Section */}
         <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
-          <div className="rounded-lg border bg-card p-6 text-card-foreground shadow-sm">
+          <div className="bg-card text-card-foreground rounded-lg border p-6 shadow-sm">
             <div className="flex items-center gap-2">
-              <FiMail className="h-5 w-5 text-muted-foreground" />
+              <FiMail className="text-muted-foreground h-5 w-5" />
               <h3 className="font-medium">Email Status</h3>
             </div>
             <p className="mt-2 text-2xl font-semibold">
@@ -180,9 +202,9 @@ export default function ProfilePage() {
             </p>
           </div>
 
-          <div className="rounded-lg border bg-card p-6 text-card-foreground shadow-sm">
+          <div className="bg-card text-card-foreground rounded-lg border p-6 shadow-sm">
             <div className="flex items-center gap-2">
-              <FiCalendar className="h-5 w-5 text-muted-foreground" />
+              <FiCalendar className="text-muted-foreground h-5 w-5" />
               <h3 className="font-medium">Member Since</h3>
             </div>
             <p className="mt-2 text-2xl font-semibold">
@@ -193,15 +215,14 @@ export default function ProfilePage() {
             </p>
           </div>
 
-          <div className="rounded-lg border bg-card p-6 text-card-foreground shadow-sm">
+          <div className="bg-card text-card-foreground rounded-lg border p-6 shadow-sm">
             <div className="flex items-center gap-2">
-              <FiMail className="h-5 w-5 text-muted-foreground" />
+              <FiMail className="text-muted-foreground h-5 w-5" />
               <h3 className="font-medium">Total Calls</h3>
             </div>
             <p className="mt-2 text-2xl font-semibold">0</p>
           </div>
         </div>
-
       </div>
     </div>
   );

--- a/apps/web/app/(app)/app/teams/page.tsx
+++ b/apps/web/app/(app)/app/teams/page.tsx
@@ -4,13 +4,16 @@ import Header from "@/components/app/header";
 import TeamSection from "@/components/app/section/team-section";
 import { useModal } from "@/hooks/use-modal";
 import { Button } from "@call/ui/components/button";
+import { CloseSidebarButton } from "@/components/app/section/_components/close-sidebar-button";
 
 export default function TeamsPage() {
   const { onOpen } = useModal();
   return (
     <div className="flex flex-col gap-[22px]">
       <Header className="justify-between">
-        <div></div>
+        <div>
+          <CloseSidebarButton className="-ml-8" />
+        </div>
         <Button
           onClick={() => onOpen("create-team")}
           className="bg-inset-accent-foreground hover:bg-inset-accent-foreground/80 text-white"

--- a/apps/web/components/app/section/_components/close-sidebar-button.tsx
+++ b/apps/web/components/app/section/_components/close-sidebar-button.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useSidebar } from "@call/ui/components/sidebar";
+import { Button } from "@call/ui/components/button";
+import { PanelRight } from "lucide-react";
+
+export function CloseSidebarButton({ className }: { className?: string }) {
+  const { toggleSidebar } = useSidebar();
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggleSidebar}
+      className={className}
+    >
+      <PanelRight className="h-4 w-4" />
+    </Button>
+  );
+}

--- a/apps/web/components/app/section/_components/nav-user.tsx
+++ b/apps/web/components/app/section/_components/nav-user.tsx
@@ -45,6 +45,17 @@ export function NavUser({
 }) {
   const { isMobile } = useSidebar();
   const router = useRouter();
+
+  function getInitials(name?: string) {
+    if (!name) return "";
+    return name
+      .trim()
+      .split(/\s+/)
+      .map((word) => word[0]?.toUpperCase())
+      .join("")
+      .slice(0, 2);
+  }
+
   const handleSignOut = async () => {
     await authClient.signOut();
     router.push("/login");
@@ -77,7 +88,9 @@ export function NavUser({
               <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
                 <Avatar className="h-8 w-8 rounded-lg">
                   <AvatarImage src={user.avatar} alt={user.name} />
-                  <AvatarFallback className="rounded-lg">CN</AvatarFallback>
+                  <AvatarFallback className="rounded-lg">
+                    {getInitials(user.name)}
+                  </AvatarFallback>
                 </Avatar>
                 <div className="grid flex-1 text-left text-sm leading-tight">
                   <span className="truncate font-medium">{user.name}</span>
@@ -85,16 +98,13 @@ export function NavUser({
                 </div>
               </div>
             </DropdownMenuLabel>
-      
-         
+
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
               <DropdownMenuItem onClick={() => router.push("/app/profile")}>
                 <BadgeCheck />
                 Account
               </DropdownMenuItem>
-           
-          
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
             <DropdownMenuItem


### PR DESCRIPTION


## Pull Request

### Description
- created a button component for switch the sidebar
- Added the component to all headers and updated avatar fallback to display user initials when no profile picture is present.

Fixes: #217

---

### Checklist

- [x] I have tested my changes locally
- [ ] I have added necessary documentation (if needed)
- [ ] I have added/updated tests (if applicable)
- [x] I have run `pnpm build` or `pnpm lint` with no errors
- [x] This pull request is ready for review

---

### Screenshots or UI Changes (if applicable)

<img width="1597" height="499" alt="image" src="https://github.com/user-attachments/assets/ad7da0b1-6214-4f8e-bd9b-905034a480b7" />
<img width="685" height="216" alt="image" src="https://github.com/user-attachments/assets/b9500f19-f7b9-4ce8-99f2-351235b4b35f" />

---

### Related Issues

NA

---

### Notes for Reviewer

we icon can be changed, that's why I tried to implement the button as a component as we have different headers for each page
