### PR TITLE
style(ui): centering the joincall box and leaving the history at the …

### DIFF
--- a/apps/web/components/app/section/call-section.tsx
+++ b/apps/web/components/app/section/call-section.tsx
@@ -9,12 +9,22 @@ interface CallSectionProps {
 
 const CallSection = ({ section }: CallSectionProps) => {
   const Sections = {
-    joincall: <JoinCallBox />,
-    history: <CallHistory />,
+    joincall: (
+      <div className="h-full w-full flex items-center justify-center">
+        <JoinCallBox />
+      </div>
+    ),
+    history: (
+      <div className="h-full w-full">
+        <CallHistory />
+      </div>
+    ),
   };
 
   return (
-    <div className="px-10 h-full w-full flex items-center justify-center">{Sections[section as keyof typeof Sections]}</div>
+    <div className="px-10 h-full w-full">
+      {Sections[section as keyof typeof Sections]}
+    </div>
   );
 };
 


### PR DESCRIPTION
…start

## Pull Request

### Description

centering the joincall box and leaving the history at the start 
Fixes: #232 (if applicable)

---

### Checklist

- [ ] I have tested my changes locally
- [ ] I have added necessary documentation (if needed)
- [ ] I have added/updated tests (if applicable)
- [ ] I have run `pnpm build` or `pnpm lint` with no errors
- [ ] This pull request is ready for review

---

### Screenshots or UI Changes (if applicable)

Add screenshots, recordings, or before/after comparisons here.

---

### Related Issues

Reference any related issues or PRs here.

---

### Notes for Reviewer

Any special instructions, context, or things to pay attention to.
