### PR TITLE
fix: add padding in call section for better UI consistency

### DIFF
--- a/apps/web/components/app/section/call-section.tsx
+++ b/apps/web/components/app/section/call-section.tsx
@@ -10,7 +10,7 @@ interface CallSectionProps {
 const CallSection = ({ section }: CallSectionProps) => {
   const Sections = {
     joincall: (
-      <div className="h-full w-full flex items-center justify-center">
+      <div className="flex h-full w-full items-center justify-center">
         <JoinCallBox />
       </div>
     ),
@@ -22,7 +22,7 @@ const CallSection = ({ section }: CallSectionProps) => {
   };
 
   return (
-    <div className="px-10 h-full w-full">
+    <div className="h-full w-full px-10 pt-4">
       {Sections[section as keyof typeof Sections]}
     </div>
   );


### PR DESCRIPTION
Adds padding to the input box in the call history section to maintain UI consistency.

Before:
<img width="1919" height="872" alt="image" src="https://github.com/user-attachments/assets/bf2f8827-d4b4-4913-9900-c358591b4146" />

After:
<img width="1919" height="872" alt="image" src="https://github.com/user-attachments/assets/ac00e1e6-24d2-4c8a-a492-94ef0853563b" />

