### PR TITLE
feat: add invite link functionality to participants sidebar

### DIFF
--- a/apps/web/components/rooms/participants-sidebar.tsx
+++ b/apps/web/components/rooms/participants-sidebar.tsx
@@ -10,6 +10,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@call/ui/components/sheet";
+import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import {
   FiCheck,
@@ -156,6 +157,20 @@ export function ParticipantsSidebar({
       console.error("Error rejecting request:", error);
     } finally {
       setLoading(false);
+    }
+  };
+
+  // Generate shareable invite URL for the current call
+  const invitePath = usePathname();
+  const inviteURL = `${window.location.origin}/${invitePath}`;
+
+  const copyInviteURL = async () => {
+    try {
+      await navigator.clipboard.writeText(inviteURL);
+      toast.success("copied!");
+    } catch (error) {
+      toast.error("Failed to copy URL");
+      console.log(error);
     }
   };
 
@@ -341,6 +356,11 @@ export function ParticipantsSidebar({
               </div>
             </>
           )}
+        </div>
+        <div className="absolute bottom-4 left-4 right-4 flex items-center justify-center">
+          <Button onClick={copyInviteURL} variant="outline" className="w-full">
+            Invite
+          </Button>
         </div>
       </SheetContent>
     </Sheet>


### PR DESCRIPTION
**Problem:**
When users joined calls, there was no way to invite additional people to the meeting. Users had to manually copy the URL from the browser address bar to share with others.

**Solution:**
Added a convenient invite link feature to the participants sidebar that allows users to copy the meeting URL with a single click.

**Changes:**
- Added invite link input field at the bottom of the participants sidebar
- Implemented one-click copy functionality with clipboard API
- Added toast notification feedback when link is successfully copied

Before:
<img width="1919" height="870" alt="image" src="https://github.com/user-attachments/assets/f41b014d-7c12-4ab0-af48-4dc2150fe820" />

After:
<img width="1919" height="873" alt="image" src="https://github.com/user-attachments/assets/1057f2d7-0630-4911-9cb6-617348f7da59" />
