### PR TITLE
feat: add invite link functionality to participants sidebar

### DIFF
--- a/apps/web/components/rooms/participants-sidebar.tsx
+++ b/apps/web/components/rooms/participants-sidebar.tsx
@@ -10,6 +10,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@call/ui/components/sheet";
+import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import {
   FiCheck,
@@ -156,6 +157,20 @@ export function ParticipantsSidebar({
       console.error("Error rejecting request:", error);
     } finally {
       setLoading(false);
+    }
+  };
+
+  // Generate shareable invite URL for the current call
+  const invitePath = usePathname();
+  const inviteURL = `${window.location.origin}/${invitePath}`;
+
+  const copyInviteURL = async () => {
+    try {
+      await navigator.clipboard.writeText(inviteURL);
+      toast.success("copied!");
+    } catch (error) {
+      toast.error("Failed to copy URL");
+      console.log(error);
     }
   };
 
@@ -341,6 +356,11 @@ export function ParticipantsSidebar({
               </div>
             </>
           )}
+        </div>
+        <div className="absolute bottom-4 left-4 right-4 flex items-center justify-center">
+          <Button onClick={copyInviteURL} variant="outline" className="w-full">
+            Invite
+          </Button>
         </div>
       </SheetContent>
     </Sheet>

--- a/apps/web/components/rooms/participants-sidebar.tsx
+++ b/apps/web/components/rooms/participants-sidebar.tsx
@@ -170,7 +170,6 @@ export function ParticipantsSidebar({
       toast.success("copied!");
     } catch (error) {
       toast.error("Failed to copy URL");
-      console.log(error);
     }
   };
 
@@ -357,7 +356,7 @@ export function ParticipantsSidebar({
             </>
           )}
         </div>
-        <div className="absolute bottom-4 left-4 right-4 flex items-center justify-center">
+        <div className="absolute bottom-4 left-4 right-4">
           <Button onClick={copyInviteURL} variant="outline" className="w-full">
             Invite
           </Button>


### PR DESCRIPTION
**Problem:**
When users joined calls, there was no way to invite additional people to the meeting. Users had to manually copy the URL from the browser address bar to share with others.

**Solution:**
Added a convenient invite link feature to the participants sidebar that allows users to copy the meeting URL with a single click.

**Changes:**
 - Added invite link input field at the bottom of the participants sidebar
 - Implemented one-click copy functionality with clipboard API
 - Added toast notification feedback when link is successfully copied
 
 Video:
 

https://github.com/user-attachments/assets/d4918642-d21a-43c8-9a47-10abeda132a0



Before:
<img width="1919" height="870" alt="image" src="https://github.com/user-attachments/assets/5a23bfcd-09c6-4931-8570-da18b619b9db" />


After:
<img width="1919" height="873" alt="image" src="https://github.com/user-attachments/assets/cf7e0022-7771-45b6-b546-e66e24d3e816" />


small suggestion: We should consider centering the toast popup at the top for better visual consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an "Invite" button to the bottom of the participants sidebar, allowing users to easily copy a shareable invite link for the current call.
  * Displays a notification confirming whether the invite link was successfully copied to the clipboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->