### PR TITLE
feat: add invite link functionality to participants sidebar and fix invite link generation 

### DIFF
--- a/apps/web/components/rooms/participants-sidebar.tsx
+++ b/apps/web/components/rooms/participants-sidebar.tsx
@@ -10,6 +10,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@call/ui/components/sheet";
+import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import {
   FiCheck,
@@ -156,6 +157,20 @@ export function ParticipantsSidebar({
       console.error("Error rejecting request:", error);
     } finally {
       setLoading(false);
+    }
+  };
+
+  // Generate shareable invite URL for the current call
+  const invitePath = usePathname();
+  const inviteURL = `${window.location.origin}/${invitePath}`;
+
+  const copyInviteURL = async () => {
+    try {
+      await navigator.clipboard.writeText(inviteURL);
+      toast.success("copied!");
+    } catch (error) {
+      toast.error("Failed to copy URL");
+      console.log(error);
     }
   };
 
@@ -341,6 +356,11 @@ export function ParticipantsSidebar({
               </div>
             </>
           )}
+        </div>
+        <div className="absolute bottom-4 left-4 right-4 flex items-center justify-center">
+          <Button onClick={copyInviteURL} variant="outline" className="w-full">
+            Invite
+          </Button>
         </div>
       </SheetContent>
     </Sheet>

--- a/apps/web/components/rooms/participants-sidebar.tsx
+++ b/apps/web/components/rooms/participants-sidebar.tsx
@@ -170,7 +170,6 @@ export function ParticipantsSidebar({
       toast.success("copied!");
     } catch (error) {
       toast.error("Failed to copy URL");
-      console.log(error);
     }
   };
 
@@ -357,7 +356,7 @@ export function ParticipantsSidebar({
             </>
           )}
         </div>
-        <div className="absolute bottom-4 left-4 right-4 flex items-center justify-center">
+        <div className="absolute bottom-4 left-4 right-4">
           <Button onClick={copyInviteURL} variant="outline" className="w-full">
             Invite
           </Button>

--- a/apps/web/components/rooms/participants-sidebar.tsx
+++ b/apps/web/components/rooms/participants-sidebar.tsx
@@ -162,14 +162,15 @@ export function ParticipantsSidebar({
 
   // Generate shareable invite URL for the current call
   const invitePath = usePathname();
-  const inviteURL = `${window.location.origin}/${invitePath}`;
+  const inviteURL = `${window.location.origin}${invitePath}`;
 
   const copyInviteURL = async () => {
     try {
       await navigator.clipboard.writeText(inviteURL);
-      toast.success("copied!");
+      toast.success("Invite link copied");
     } catch (error) {
-      toast.error("Failed to copy URL");
+      console.error("Error copying invite URL:", error);
+      toast.error("Failed to copy invite link");
     }
   };
 


### PR DESCRIPTION
**Problem:**
When users joined calls, there was no way to invite additional people to the meeting. Users had to manually copy the URL from the browser address bar to share with others.

**Solution:**
Added a convenient invite link feature to the participants sidebar that allows users to copy the meeting URL with a single click.

**Changes:**
 - Added invite link input field at the bottom of the participants sidebar
 - Implemented one-click copy functionality with the clipboard API
 - Added toast notification feedback when the link is successfully copied
 
 Video:
 
 

https://github.com/user-attachments/assets/cd5a23b1-4495-4a4b-a794-88fdb33da767


**Screenshots:**

 - Before:
<img width="1919" height="870" alt="Screenshot 2025-08-10 120623" src="https://github.com/user-attachments/assets/de733c59-0565-4c5f-bccc-097a19a0a216" />

 - After:
<img width="1919" height="873" alt="Screenshot 2025-08-10 120639" src="https://github.com/user-attachments/assets/7bf616f2-15ce-4967-af43-ddf80b25ef68" />


small suggestion: we should consider centring the toast popup at the top for better visual consistency.

