### PR TITLE
fix: user profile image in others section

### DIFF
--- a/apps/web/components/modal/contact-selector.tsx
+++ b/apps/web/components/modal/contact-selector.tsx
@@ -1,7 +1,7 @@
 import { useContacts } from "@/components/providers/contacts";
-import { Avatar } from "@call/ui/components/avatar";
 import { Checkbox } from "@call/ui/components/checkbox";
 import { Input } from "@call/ui/components/input";
+import { UserProfile } from "@call/ui/components/use-profile";
 import { Search } from "lucide-react";
 import { useState } from "react";
 
@@ -85,14 +85,12 @@ export function ContactSelector({
                 }
                 disabled={disabled}
               />
-              <Avatar className="h-8 w-8">
-                <div
-                  key={`avatar-${contact.id}`}
-                  className="bg-primary/10 text-primary flex h-full w-full items-center justify-center rounded-full text-sm font-medium"
-                >
-                  {contact.name.charAt(0).toUpperCase()}
-                </div>
-              </Avatar>
+              <UserProfile
+                name={contact.name}
+                url={contact.image}
+                size="sm"
+                className="border-inset-accent border"
+              />
               <div className="min-w-0 flex-1">
                 <div className="truncate font-medium">{contact.name}</div>
                 <div className="text-muted-foreground truncate text-xs">

--- a/apps/web/components/rooms/participants-sidebar.tsx
+++ b/apps/web/components/rooms/participants-sidebar.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Avatar } from "@call/ui/components/avatar";
 import { Badge } from "@call/ui/components/badge";
 import { Button } from "@call/ui/components/button";
 import { Separator } from "@call/ui/components/separator";
@@ -21,6 +20,7 @@ import { toast } from "sonner";
 interface Participant {
   id: string;
   displayName: string;
+  image?: string;
   isCreator?: boolean;
   isMicOn?: boolean;
   isCameraOn?: boolean;
@@ -155,7 +155,12 @@ export function ParticipantsSidebar({
         {creator && (
           <div className="mb-4">
             <div className="flex items-center gap-2">
-              <UserProfile name={creator.displayName} />
+              <UserProfile
+                name={creator.displayName}
+                url={creator.image}
+                size="sm"
+                className="border-inset-accent border"
+              />
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-2">
                   <p className="truncate text-sm font-medium text-gray-900 dark:text-gray-100">
@@ -164,7 +169,6 @@ export function ParticipantsSidebar({
                       : creator.displayName}
                   </p>
                 </div>
-             
               </div>
             </div>
           </div>
@@ -189,11 +193,12 @@ export function ParticipantsSidebar({
                     : "bg-muted/50"
                 }`}
               >
-                <Avatar className="h-8 w-8">
-                  <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-purple-600 text-sm font-medium text-white">
-                    {participant.displayName.charAt(0).toUpperCase()}
-                  </div>
-                </Avatar>
+                <UserProfile
+                  name={participant.displayName}
+                  url={participant.image}
+                  size="sm"
+                  className="border-inset-accent border"
+                />
 
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
@@ -203,7 +208,6 @@ export function ParticipantsSidebar({
                         : participant.displayName}
                     </p>
                   </div>
-              
                 </div>
               </div>
             ))}
@@ -236,11 +240,12 @@ export function ParticipantsSidebar({
                     className="bg-background rounded-lg border p-3"
                   >
                     <div className="flex items-start gap-3">
-                      <Avatar className="h-8 w-8">
-                        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gradient-to-br from-green-500 to-blue-600 text-sm font-medium text-white">
-                          {request.userName.charAt(0).toUpperCase()}
-                        </div>
-                      </Avatar>
+                      <UserProfile
+                        name={request.userName}
+                        url={undefined}
+                        size="sm"
+                        className="border-inset-accent border"
+                      />
 
                       <div className="min-w-0 flex-1">
                         <p className="text-sm font-medium">


### PR DESCRIPTION
## Pull Request

### Description

This PR fixes profile image display issues throughout the application by replacing hardcoded avatar placeholders with actual user profile images. The changes ensure that users see real profile photos instead of generic initials in various components including the contact selector, participants sidebar, and other user avatar displays.

**Key Changes:**
- **ContactSelector**: Replaced hardcoded Avatar with initials with UserProfile component
- **ParticipantsSidebar**: Updated to display actual participant profile images
- **UserProfile Component**: Enhanced to properly handle image URLs and fallbacks
- **Call Page**: Added participant image data to the participants construction

**Dependencies Required:**
- No new dependencies added
- Uses existing `@call/ui/components/use-profile` component
- Requires user profile images to be set in the database

---

### Checklist

- [x] I have tested my changes locally
- [x] I have added necessary documentation (if needed)
- [ ] I have added/updated tests (if applicable)
- [x] I have run `pnpm build` or `pnpm lint` with no errors
- [x] This pull request is ready for review

---

### Screenshots or UI Changes (if applicable)

**Before:** Contact selector showed hardcoded colored divs with user initials
**After:** Contact selector now displays actual user profile images with fallback to initials

**Before:** Participants sidebar showed generic colored avatars with initials
**After:** Participants sidebar now shows actual user profile images when available

---

### Related Issues

Fixes profile image display issues in:
- Contact selection modal
- Call participants sidebar
- User avatar displays throughout the app

---

### Notes for Reviewer

**ContactSelector Changes (`apps/web/components/modal/contact-selector.tsx`):**
- Replaced `Avatar` import with `UserProfile` import
- Changed hardcoded `<Avatar>` with colored div and initials to `<UserProfile>` component
- Now properly displays `contact.image` when available
- Falls back to user initials when no profile image exists
- Maintains consistent styling with `border-inset-accent border` class

**ParticipantsSidebar Changes (`apps/web/components/rooms/participants-sidebar.tsx`):**
- Updated `Participant` interface to include `image?: string` field
- Replaced hardcoded Avatar components with `UserProfile` components
- Added missing `url` prop to creator's UserProfile component
- Now displays actual profile images for participants with images set
- Clean fallback to initials for participants without profile images

**UserProfile Component Changes (`packages/ui/src/components/use-profile.tsx`):**
- Added conditional rendering for `AvatarImage` (only renders when URL exists)
- Added proper `alt` text for accessibility
- Prevents fallback issues when URL is undefined/null
- Better error handling for missing image URLs

**Call Page Changes (`apps/web/app/(app)/app/call/[id]/page.tsx`):**
- Added `getParticipantImage()` function to handle profile image logic
- Updated participants construction to include profile image data
- Current user now sees their own profile image in participants list
- Other participants show initials (ready for future backend integration)

**Impact:**
- Users now see actual profile photos instead of generic placeholders
- Better user experience with recognizable profile images
- Consistent avatar styling across all components
- Proper fallback handling when profile images are not available

**Testing Notes:**
- Test with users who have profile images set
- Test with users who don't have profile images (should show initials)
- Verify contact selector displays profile images correctly
- Verify participants sidebar shows profile images for current user
- Check that fallbacks work properly when images are missing