### PR TITLE
fix: give contact page same top spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Ready to escape complex, data-hungry meeting apps? Join the future of video call
 ./setup-dev.sh
 ```
 
-2.2 2. **Start the development environment (Windows)**
+2.2 **Start the development environment (Windows)**
 
 ```bash
 ./setup_dev_windows.sh

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Ready to escape complex, data-hungry meeting apps? Join the future of video call
 ./setup-dev.sh
 ```
 
-2.2 2. **Start the development environment (Winodws)**
+2.2 2. **Start the development environment (Windows)**
 
 ```bash
 ./setup_dev_windows.sh

--- a/apps/web/components/app/section/contacts-list.tsx
+++ b/apps/web/components/app/section/contacts-list.tsx
@@ -133,7 +133,7 @@ export default function ContactsList({ onAddContact }: ContactsListProps) {
 
   if (user.id === "guest") {
     return (
-      <div className="px-10 py-6">
+      <div className="px-10 space-y-6">
         <NoContactsFound onAddContact={onAddContact} />
       </div>
     );


### PR DESCRIPTION
### Description

Noticed the spacing at the top of the Contact page was different to the teams/notification page so I gave them both the same spacing, also fixed a small typo in the readme I noticed.

---

### Checklist

- [x] I have tested my changes locally
- [x] I have added necessary documentation (if needed)
- [x] I have added/updated tests (if applicable)
- [x] I have run `pnpm build` or `pnpm lint` with no errors
- [x] This pull request is ready for review

---

### Screenshots or UI Changes (if applicable)

Before: 

<img width="1638" height="516" alt="image" src="https://github.com/user-attachments/assets/80bcdec0-40fe-461b-920d-224d2e8a969b" />

After:

<img width="1627" height="571" alt="image" src="https://github.com/user-attachments/assets/1b8b1d3e-0127-4bd1-9f45-aa48e71591f7" />

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Documentation
  * Corrected a typo in the Quick Start guide, fixing the spelling of “Windows” and normalizing the numbered bullet formatting.

* Style
  * Improved vertical spacing in the guest contacts list view by switching to consistent gap-based spacing for better visual separation and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->