### PR TITLE
fix: show user profile picture when camera is off for remote particip…

### DIFF
--- a/apps/server/src/mediasoup-server.ts
+++ b/apps/server/src/mediasoup-server.ts
@@ -884,6 +884,7 @@ wss.on("connection", (ws: WebSocket) => {
               rtpParameters: consumer.rtpParameters,
               peerId: targetPeer.id,
               displayName: targetPeer.displayName,
+              userImage: targetPeer.userImage,
               source: myProducer.source,
               muted: myProducer.muted || false,
             };

--- a/apps/web/components/call/call-video-grid.tsx
+++ b/apps/web/components/call/call-video-grid.tsx
@@ -302,6 +302,17 @@ export const CallVideoGrid = memo(() => {
         if (!stream) return;
         if (kind !== "video") return;
 
+        console.log(`[VideoGrid] Processing remote stream:`, {
+          peerId,
+          displayName,
+          producerId,
+          kind,
+          source,
+          muted,
+          userImage: remoteUserImage,
+          hasValidTrack: stream.getVideoTracks().some((t) => t.readyState === "live" && t.enabled)
+        });
+
         // Include streams even if they don't have valid tracks (muted streams)
         // This ensures we show profile pictures for users with cameras off
         const hasValidTrack = stream


### PR DESCRIPTION
…ants

## Pull Request

### Description

Fix: When the user turns off the camera before joining the call, their profile picture is now visible on both sides

Fixes: #271 (if applicable)

---

### Checklist

- [ ] I have tested my changes locally
- [ ] I have added necessary documentation (if needed)
- [ ] I have added/updated tests (if applicable)
- [ ] I have run `pnpm build` or `pnpm lint` with no errors
- [ ] This pull request is ready for review

---

### Screenshots or UI Changes (if applicable)

Add screenshots, recordings, or before/after comparisons here.

---

### Related Issues

Reference any related issues or PRs here.

---

### Notes for Reviewer

Any special instructions, context, or things to pay attention to.
