### PR TITLE
feat(app): add global 404 not-found page

### DIFF
--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import { Button } from "@call/ui/components/button";
+import { Undo2 } from "lucide-react";
+
+export const metadata = {
+  title: "404 | Page Not Found - Call",
+  description:
+    "Oops! The page you’re looking for isn’t available. Head back to the homepage.",
+};
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex bg-background items-center justify-center px-6">
+      <div className="text-center max-w-md">
+        <h1 className="text-6xl font-bold text-primary mb-6">404</h1>
+        <p className="text-muted-foreground">
+          Looks like you&apos;ve wandered off the call. The page you&apos;re trying to reach
+          doesn&apos;t exist or maybe it&apos;s on mute.  
+        </p>
+        <p className="text-muted-foreground mb-8">
+          Let&apos;s get you back on track.
+        </p>
+        <Button asChild>
+          <Link href="/" className="flex items-center gap-2">
+            <Undo2 className="h-4 w-4" aria-hidden="true" focusable="false" />
+            <span>Go Back Home</span>
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Description

Added a **global `not-found.tsx` page** under `apps/web/app`.
This ensures that whenever a user navigates to a non-existent route, they’re shown a branded 404 experience instead of the default blank/error page of next.js.

* Implemented a clean and minimal **404 UI** consistent with the Call brand theme.
* Added metadata (`title` + `description`) for better SEO.
* Included a **Go Back Home** button

Fixes: N/A

---

### Checklist

* [x] I have tested my changes locally
* [ ] I have added necessary documentation (if needed)
* [ ] I have added/updated tests (if applicable)
* [x] I have run `pnpm build` or `pnpm lint` with no errors
* [x] This pull request is ready for review

---

### Screenshots or UI Changes (if applicable)

**Before:**
No dedicated 404 page → fallback error screen.

<img width="1920" height="1023" alt="image" src="https://github.com/user-attachments/assets/85dd3782-06ec-4582-97fe-cbaee88ad3ac" />


**After:**
A centered, branded page with:
* Large **404** heading
* Playful copy: “Looks like you’ve wandered off the call...”
* A single **Go Back Home** button
<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/03ae80aa-cd26-4c8a-b780-1195e65c46c2" />

---

### Related Issues

N/A

---

### Notes for Reviewer

* This page is **global** across all routes.
* Kept copy and style light and brand-aligned.
* Didn’t add a “Back” button to previous page, only **Home** button as discussed.

---