### PR TITLE
feat(footer): add social links for GitHub, Discord, and Twitter

### DIFF
--- a/apps/web/app/(waitlist)/_components/footer.tsx
+++ b/apps/web/app/(waitlist)/_components/footer.tsx
@@ -26,21 +26,24 @@ const Footer = () => {
             </p>
             <div className="flex items-center gap-2">
               <Link
-                href="#"
+                href="https://github.com/Call0dotco/call"
+                target="_blank"
                 aria-label="GitHub"
                 className="rounded-md p-2 hover:bg-muted-foreground/10"
               >
                 <Icons.github className="size-4" />
               </Link>
               <Link
-                href="#"
+                href="https://discord.com/invite/bre4echNxB"
+                target="_blank"
                 aria-label="Discord"
                 className="rounded-md p-2 hover:bg-muted-foreground/10"
               >
                 <Icons.discord />
               </Link>
               <Link
-                href="#"
+                href="https://x.com/joincalldotco"
+                target="_blank"
                 aria-label="X"
                 className="rounded-md p-2 hover:bg-muted-foreground/10"
               >


### PR DESCRIPTION
### Description
Added social media links to the footer:  
- GitHub: [https://github.com/Call0dotco/call](https://github.com/Call0dotco/call)  
- Discord: [https://discord.com/invite/bre4echNxB](https://discord.com/invite/bre4echNxB)  
- Twitter (X): [https://x.com/joincalldotco](https://x.com/joincalldotco)

All links use `target="_blank"` to open in new tabs.  

No new dependencies were introduced for this change.

### Checklist
- [x] I have tested my changes locally
- [ ] I have added necessary documentation (if needed)
- [ ] I have added/updated tests (if applicable)
- [x] I have run `pnpm build` or `pnpm lint` with no errors
- [x] This pull request is ready for review

---

### Screenshots or UI Changes (if applicable)
**Before:**  
Footer displayed no social links.

https://github.com/user-attachments/assets/3e47e1d2-f629-4da5-9559-d8d346652a74


**After:**  
Footer now shows GitHub, Discord, and Twitter/X links, all opening in new tabs.

https://github.com/user-attachments/assets/2db3aec0-5dca-40fa-a72a-93c25373b2d6

---

### Related Issues
_Fixes:_ N/A

---

### Notes for Reviewer
- Please confirm accessibility and styling of new icons/links.
- No dependencies modified.
- Let me know if you recommend adding textual labels or alt text for further accessibility.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated footer social icons (GitHub, Discord, X) to link to their official external pages.
  * Links now open in new tabs for smoother navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->